### PR TITLE
Fix stray brace causing lint parse error

### DIFF
--- a/components/dashboard/patient/RequestServiceModal.tsx
+++ b/components/dashboard/patient/RequestServiceModal.tsx
@@ -23,7 +23,6 @@ const RequestServiceModal: React.FC<Props> = ({ isOpen, onClose, defaultServiceT
     e.preventDefault();
     if (userType !== 'patient' || !user || !token) return;
     const patient = user as PatientProfile;
-    }
     setIsSubmitting(true);
     const payload = {
       orderId: `order_${Date.now()}`,


### PR DESCRIPTION
## Summary
- remove stray closing brace in `RequestServiceModal.tsx`
- confirm lint runs without parsing errors

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68583ea21864832a9e4a5e19640b2ce9