### PR TITLE
Fix typings for test login and map

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,0 @@
-node_modules
-dist
-api/node_modules

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,5 +1,6 @@
 module.exports = {
   root: true,
+  ignorePatterns: ['node_modules', 'dist', 'api/node_modules'],
   env: { browser: true, node: true, es2020: true },
   parser: '@typescript-eslint/parser',
   parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },

--- a/components/auth/TestLoginPanel.tsx
+++ b/components/auth/TestLoginPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { TEST_USERS } from '../../mock/testUsers';
 import { useAuth } from '../../hooks/useAuth';
+import { AuthResponseData, NurseStatus } from '../../types';
 
 interface TestUser {
   id: string;
@@ -14,8 +15,33 @@ const TestLoginPanel: React.FC = () => {
   const { login } = useAuth();
 
   const loginAs = (user: TestUser, type: 'patient' | 'nurse') => {
-    // Minimal authentication simulation
-    login({ token: 'mock-token', [type]: { id: user.id, name: user.name } } as any, type as any);
+    const [firstName, ...lastNameParts] = user.name.split(' ');
+    const lastName = lastNameParts.join(' ') || 'User';
+
+    const data: AuthResponseData = { token: 'mock-token' };
+
+    if (type === 'patient') {
+      data.patient = {
+        patient_id: user.id,
+        first_name: firstName,
+        last_name: lastName,
+        email: `${user.id}@example.com`,
+        account_status: 'active',
+      };
+    } else {
+      data.nurse = {
+        nurse_id: user.id,
+        first_name: firstName,
+        last_name: lastName,
+        email: `${user.id}@example.com`,
+        account_status: 'active',
+        verification_status: 'verified',
+        is_online: true,
+        current_status: (user.status as NurseStatus) || NurseStatus.AVAILABLE,
+      };
+    }
+
+    login(data, type);
   };
 
   return (

--- a/components/common/UserLocationMap.tsx
+++ b/components/common/UserLocationMap.tsx
@@ -27,7 +27,7 @@ const UserLocationMap: React.FC<Props> = ({ latitude, longitude }) => {
   const center: GoogleLatLng = position || { lat: 37.7749, lng: -122.4194 };
 
   return (
-    <LoadScript googleMapsApiKey={(import.meta as any).env?.VITE_GOOGLE_MAPS_API_KEY || ''}>
+    <LoadScript googleMapsApiKey={import.meta.env.VITE_GOOGLE_MAPS_API_KEY || ''}>
       <GoogleMap mapContainerStyle={{ height: '250px', width: '100%' }} center={center} zoom={13}>
         {position && <Marker position={position} />}
       </GoogleMap>

--- a/components/dashboard/patient/RequestServiceModal.tsx
+++ b/components/dashboard/patient/RequestServiceModal.tsx
@@ -23,7 +23,6 @@ const RequestServiceModal: React.FC<Props> = ({ isOpen, onClose, defaultServiceT
     e.preventDefault();
     if (userType !== 'patient' || !user || !token) return;
     const patient = user as PatientProfile;
-    }
     setIsSubmitting(true);
     const payload = {
       orderId: `order_${Date.now()}`,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev:all": "concurrently -k \"npm run dev:api\" \"npm run dev\"",
     "seed": "npm --prefix api run seed",
     "build": "tsc && vite build",
-    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0 --config .eslintrc.cjs",
     "test": "vitest run",
     "preview": "vite preview"
   },

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_GOOGLE_MAPS_API_KEY?: string;
+  readonly VITE_API_BASE_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- remove `any` from test login authentication
- type environment variables for Vite
- remove geolocation cast to `any`
- fix lint parse issue in request service modal

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68583ea3bec8832ab481255812630f17