### PR TITLE
Fix patient dashboard location lookup

### DIFF
--- a/components/dashboard/patient/FindNursesPanel.tsx
+++ b/components/dashboard/patient/FindNursesPanel.tsx
@@ -8,6 +8,10 @@ import Button from '../../common/Button';
 import Select from '../../common/Select';
 import LoadingSpinner from '../../common/LoadingSpinner';
 import NurseCard from './NurseCard';
+import { NURSE_SPECIALTY_OPTIONS, CA_PROVINCES } from '../../../constants';
+import RequestServiceModal from './RequestServiceModal';
+import UserLocationMap from '../../common/UserLocationMap';
+import { geocodeAddress, reverseGeocode } from '../../../services/geocodingService';
 
 const FindNursesPanel: React.FC = () => {
   const [street, setStreet] = useState<string>('');
@@ -76,6 +80,32 @@ const FindNursesPanel: React.FC = () => {
     } else {
       setError((response.error as ApiError)?.message || "Failed to fetch nurses. Please try again.");
     }
+  };
+
+  const handleUseCurrentLocation = async () => {
+    if (!navigator.geolocation) {
+      setError('Geolocation not supported by your browser.');
+      return;
+    }
+    setIsLoading(true);
+    navigator.geolocation.getCurrentPosition(
+      async (p) => {
+        const { latitude, longitude } = p.coords;
+        setCoords({ lat: latitude, lng: longitude });
+        const addr = await reverseGeocode(latitude, longitude);
+        if (addr) {
+          if (addr.street) setStreet(addr.street);
+          if (addr.city) setCity(addr.city);
+          if (addr.state) setStateProv(addr.state);
+          if (addr.zip) setZip(addr.zip);
+        }
+        setIsLoading(false);
+      },
+      () => {
+        setError('Unable to retrieve your current location.');
+        setIsLoading(false);
+      }
+    );
   };
   
   const serviceTypeOptions = [

--- a/services/geocodingService.ts
+++ b/services/geocodingService.ts
@@ -18,3 +18,35 @@ export async function geocodeAddress(address: string): Promise<[number, number] 
     return null;
   }
 }
+
+export interface ReverseGeocodeResult {
+  street?: string;
+  city?: string;
+  state?: string;
+  zip?: string;
+}
+
+export async function reverseGeocode(lat: number, lon: number): Promise<ReverseGeocodeResult | null> {
+  try {
+    const url = `https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lon}`;
+    const res = await fetch(url, {
+      headers: {
+        'Accept-Language': 'en',
+        'User-Agent': 'QuickNurseDemo/1.0'
+      }
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    if (data && data.address) {
+      return {
+        street: data.address.road || data.address.house_number ? `${data.address.house_number || ''} ${data.address.road || ''}`.trim() : undefined,
+        city: data.address.city || data.address.town || data.address.village,
+        state: data.address.state || data.address.region,
+        zip: data.address.postcode,
+      };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add reverse geocoding service
- use geolocation when patient clicks **Use My Current Location** on the patient dashboard
- ensure constants and modals imported for patient dashboard map

## Testing
- `npm run lint` *(fails: A config object is using the "root" key)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685843fbd628832a9dc2b466950f75c2